### PR TITLE
Add graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,14 +25,8 @@ func main() {
 
 	todoService := service.NewToDoService(db)
 
-	err = server.Run(
+	server.Run(
 		cfg,
 		todoService,
 	)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	return
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"context"
 	"fmt"
-
+	"github.com/labstack/gommon/log"
 	"github.com/luiz-mai/go-api-boilerplate/config"
 	"github.com/luiz-mai/go-api-boilerplate/server/handler"
 	"github.com/luiz-mai/go-api-boilerplate/service"
+	"os"
+	"os/signal"
+	"time"
 
 	"github.com/labstack/echo"
 )
@@ -13,7 +17,7 @@ import (
 func Run(
 	cfg config.Config,
 	todoService service.ToDoService,
-) (err error) {
+) {
 	e := echo.New()
 	e.HideBanner = true
 
@@ -25,10 +29,21 @@ func Run(
 	e.PUT("/todos/:id", handler.HandleUpdateToDo(todoService))
 	e.DELETE("/todos/:id", handler.HandleDeleteToDo(todoService))
 
-	err = e.Start(fmt.Sprintf(":%d", cfg.HTTP.Port))
-	if err != nil {
-		return err
-	}
+	// Start server
+	go func() {
+		if err := e.Start(fmt.Sprintf(":%d", cfg.HTTP.Port)); err != nil {
+			log.Warn("shutting down server")
+		}
+	}()
 
-	return nil
+	// Wait for interrupt signal to gracefully shutdown the server with
+	// a timeout of 10 seconds.
+	quit := make(chan os.Signal)
+	signal.Notify(quit, os.Interrupt)
+	<-quit
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := e.Shutdown(ctx); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Add graceful shutdown for cases there are ongoing requests, then the server waits for a period of time, before shutting it down and it doesn't allow new requests while shutting down.